### PR TITLE
Fixed nav bar and plotly buttons not showing properly

### DIFF
--- a/iron_handmaidens/data/templates/data/visualize.html
+++ b/iron_handmaidens/data/templates/data/visualize.html
@@ -14,18 +14,6 @@
 		h3{
 			font-family: AlteHaasGroteskBold;
 		}
-		a{
-			background-color: black;
-			border: none;
-			border-radius: 8px;
-			box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2), 0 6px 20px 0 rgba(0,0,0,0.19);
-			color: #1A73E8;
-			cursor: pointer;
-			display: inline-block;
-			font-family: AlteHaasGroteskBold;
-			font-size:25px;
-			padding: 15px 32px;
-		}
 	</style>
 	<script src="https://cdn.plot.ly/plotly-2.9.0.min.js"></script>
 	<!---Title and other setup of graph.-->


### PR DESCRIPTION
Removed "a" class from visualize styling, as it was affecting both the nav bar buttons and the plotly buttons, which cannot be the same color. Removing this fixed the formatting issues and appeared to change nothing else.